### PR TITLE
Check if `sharedParamsFileName` doesn't exist

### DIFF
--- a/TraverseAllSystems/SharedParameterMgr.cs
+++ b/TraverseAllSystems/SharedParameterMgr.cs
@@ -80,7 +80,8 @@ namespace TraverseAllSystems
         = app.SharedParametersFilename;
 
       if( null == sharedParamsFileName
-        || 0 == sharedParamsFileName.Length )
+        || 0 == sharedParamsFileName.Length
+        || !File.Exists(sharedParamsFileName) )
       {
         string path = Path.GetTempPath();
 


### PR DESCRIPTION
`app.OpenSharedParameterFile();` retuns `null` even if `app.SharedParametersFilename` is not null. (Related issue #3 )

Modified the code to check if the `sharedParamsFileName` actually exists in the users file system.